### PR TITLE
Update README to reflect reality

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 QWebDAV Library (qwebdavlib) version 1.0
 
-is a library for Qt4 and provides access to WebDAV servers.
+is a library for Qt4, Qt5 and Qt6 and provides access to WebDAV servers.
 WebDAV is an extension for HTTP, so that a Web server can
 provide write access in addition to read access. The WebDAV
 standard provides the essential functionalities to access

--- a/README
+++ b/README
@@ -7,12 +7,12 @@ standard provides the essential functionalities to access
 a Web server like a file server.
 
 More information
-    http://en.wikipedia.org/wiki/WebDAV
+    https://en.wikipedia.org/wiki/WebDAV
 
 WebDAV standard as RFC4918:
     "HTTP Extensions for Web Distributed Authoring and
     Versioning (WebDAV)" from June 2007
-        http://tools.ietf.org/html/rfc4918
+        https://datatracker.ietf.org/doc/html/rfc4918
 
 This library has been derived from previous works
     QWebdav plugin for MeeDav (LGPL v2.1)
@@ -22,21 +22,21 @@ This library has been derived from previous works
 
 Tested WebDAV server:
     * Apache HTTP Server with mod_dav
-        Apache/2.2.14, http://httpd.apache.org/
+        Apache/2.2.14, https://httpd.apache.org/
     * Microsoft Internet Information Service 7.5 (MS IIS 7.5)
       as used by Windows 7 and Windows Server 2008 R2
     * SabreDAV - WebDAV framework for PHP
-        SabreDAV 1.6.1-stable, http://code.google.com/p/sabredav/
+        SabreDAV 1.6.1-stable, https://sabre.io/dav/
 
 QWebdav Library supports the following authentication methods:
 (as provided by Qt4)
 
     * Basic
-        http://en.wikipedia.org/wiki/Basic_access_authentication
+        https://en.wikipedia.org/wiki/Basic_access_authentication
     * NTLM version 1 (older Windows challenge-response authentication)
-        http://en.wikipedia.org/wiki/NTLM
+        https://en.wikipedia.org/wiki/NTLM
     * Digest-MD5
-        http://en.wikipedia.org/wiki/Digest_access_authentication
+        https://en.wikipedia.org/wiki/Digest_access_authentication
 
     More information on authentication by Qt4
         http://qt-project.org/doc/qt-4.7/qauthenticator.html

--- a/README
+++ b/README
@@ -28,15 +28,22 @@ Tested WebDAV server:
     * SabreDAV - WebDAV framework for PHP
         SabreDAV 1.6.1-stable, https://sabre.io/dav/
 
-QWebdav Library supports the following authentication methods:
-(as provided by Qt4)
+QWebdav Library supports the following authentication methods,
+depending on the Qt version it is built with:
 
-    * Basic
+    * Basic (Qt4, Qt5, Qt6)
         https://en.wikipedia.org/wiki/Basic_access_authentication
-    * NTLM version 1 (older Windows challenge-response authentication)
+    * NTLM version 1 (older Windows challenge-response authentication) (Qt4)
         https://en.wikipedia.org/wiki/NTLM
-    * Digest-MD5
+    * NTLM version 2 (Qt5, Qt6)
+        https://en.wikipedia.org/wiki/NTLM#NTLMv2
+    * Digest-MD5 (Qt4, Qt5, Qt6)
         https://en.wikipedia.org/wiki/Digest_access_authentication
+    * SPNEGO (Qt5, Qt6)
+        https://en.wikipedia.org/wiki/SPNEGO
 
-    More information on authentication by Qt4
-        http://qt-project.org/doc/qt-4.7/qauthenticator.html
+More information on authentication:
+    * Qt5
+        https://doc.qt.io/archives/qt-5.15/qauthenticator.html
+    * Qt6
+        https://doc.qt.io/qt-6/qauthenticator.html


### PR DESCRIPTION
Although this is a bit of trivia, the README says emphatically "Qt4" even though the library builds fine with Qt5 and Qt6 (and, seriously, nobody uses Qt4 anymore). This PR mentions recent Qt, uses https: links when possible, and explains what authentications are possible with QAuthenticator in Qt5 and Qt6.