### PR TITLE
Reduce compile warnings

### DIFF
--- a/qwebdavlib/qnaturalsort.cpp
+++ b/qwebdavlib/qnaturalsort.cpp
@@ -67,7 +67,7 @@ static inline QChar getNextChar(const QString &s, int location)
   */
 int QNaturalSort::naturalCompare(const QString &s1, const QString &s2,  Qt::CaseSensitivity cs)
 {
-    for (int l1 = 0, l2 = 0; l1 <= s1.count() && l2 <= s2.count(); ++l1, ++l2) {
+    for (int l1 = 0, l2 = 0; l1 <= s1.size() && l2 <= s2.size(); ++l1, ++l2) {
         // skip spaces, tabs and 0's
         QChar c1 = getNextChar(s1, l1);
         while (c1.isSpace())

--- a/qwebdavlib/qwebdavdirparser.cpp
+++ b/qwebdavlib/qwebdavdirparser.cpp
@@ -309,7 +309,11 @@ void QWebdavDirParser::parseMultiResponse(const QByteArray &data)
         return;
 
     QDomDocument multiResponse;
-    multiResponse.setContent(data, true);
+#if QT_VERSION < 0x060800
+    multiResponse.setContent(data, true /* with namespace processing */);
+#else
+    multiResponse.setContent(data, QDomDocument::ParseOption::UseNamespaceProcessing);
+#endif
 
     for(QDomNode n = multiResponse.documentElement().firstChild(); !n.isNull(); n = n.nextSibling())
     {

--- a/qwebdavlib/qwebdavdirparser.cpp
+++ b/qwebdavlib/qwebdavdirparser.cpp
@@ -408,7 +408,7 @@ void QWebdavDirParser::davParsePropstats(const QString &path, const QDomNodeList
 #endif
 
     // name
-#if QT_VERSION < 0x060000
+#if QT_VERSION < 0x050e00
     QStringList pathElements = path_.split('/', QString::SkipEmptyParts);
 #else
     QStringList pathElements = path_.split('/', Qt::SkipEmptyParts);


### PR DESCRIPTION
In Qt5 and Qt6 some APIs were deprecated. Those produce unnecessary noise during compilation, because the code can easily adapt to the non-deprecated API -- there are already `#if` checks for Qt versions in the code.

This PR drops the number of compile-time warnings (with gcc, default options but also `-Wall -Werror`, on Debian 13) to zero.