### PR TITLE
Improve CMake & pkgconfig compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0 FATAL_ERROR)
 
 project(QWebdav
-  VERSION 1.0
+  VERSION 1.0.0
   DESCRIPTION "WebDAV server access"
   HOMEPAGE_URL "https://github.com/fredldotme/qwebdavlib"
   LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ install(
 #
 #
 add_subdirectory(qwebdavlib)
+add_subdirectory(qwebdavlibExample)
 
 ### CMake Configuration Files
 #

--- a/QWebdavConfig.cmake.in
+++ b/QWebdavConfig.cmake.in
@@ -23,7 +23,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/QWebdavTargets.cmake")
 
 # Versionless alias, prefer Qt6 over Qt5
 if(_qwebdav_WITH_QT6)
-  add_library(QWebdav ALIAS QWebdav-qt6)
+  add_library(QWebdav ALIAS qwebdav-qt6)
 else()
-  add_library(QWebdav ALIAS QWebdav-qt5)
+  add_library(QWebdav ALIAS qwebdav-qt5)
 endif()

--- a/README
+++ b/README
@@ -47,3 +47,34 @@ More information on authentication:
         https://doc.qt.io/archives/qt-5.15/qauthenticator.html
     * Qt6
         https://doc.qt.io/qt-6/qauthenticator.html
+
+
+## Building QWebDAV
+
+The library can be built with your choice of meta-buildsystem:
+CMake or qmake. There are minor differences in the resulting
+installed files:
+- CMake build installs only one copy of the headers, and installs
+  both CMake and pkgconfig files for finding the library.
+  The SOVERSION is 1, which can be linked as .so, .so.1 and .so.1.0.0.
+- qmake build installs one copy of the headers per Qt version and
+  installs only pkgconfig files. The SOVERSION is 1, which can
+  be linked as .so, .so.1, .so.1.0 and .so.1.0.0.
+
+An example program is also built, but not installed.
+
+## Using QWebDAV from your Project
+
+If your project uses CMake as a meta-buildsystem, the `qwebdavlibExample/`
+directory contains an example of how to do so. Use `find_package(QWebdav)`
+as shown in the example. You can also use CMake's `pkgconfig` support,
+also shown in the example. If your project uses another buildsystem,
+use `pkgconfig` to find QWebDAV.
+
+To use this example as an independent build, run
+```
+cmake -S qwebdavlibExample -B build-example
+make -C build-example
+```
+(optionally, use a different `-B` build directory, or a different
+build-system generator like `-G Ninja`)

--- a/qwebdavlib/CMakeLists.txt
+++ b/qwebdavlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Boilerplate for building the library against a given Qt version
 function(add_qwebdav_library QT_VERSION)
-  add_library(QWebdav-qt${QT_VERSION})
-  target_sources(QWebdav-qt${QT_VERSION}
+  add_library(qwebdav-qt${QT_VERSION})
+  target_sources(qwebdav-qt${QT_VERSION}
     PRIVATE
       qnaturalsort.cpp
       qwebdav.cpp
@@ -9,44 +9,44 @@ function(add_qwebdav_library QT_VERSION)
       qwebdavitem.cpp
   )
 
-  target_compile_definitions(QWebdav-qt${QT_VERSION}
+  target_compile_definitions(qwebdav-qt${QT_VERSION}
     PRIVATE
       QWEBDAV_LIBRARY=1
       QWEBDAVITEM_EXTENDED_PROPERTIES=1
   )
   if(CMAKE_BUILD_TYPE STREQUAL Release)
-    target_compile_definitions(QWebdav-qt${QT_VERSION}
+    target_compile_definitions(qwebdav-qt${QT_VERSION}
       PRIVATE
         QT_NO_DEBUG_OUTPUT=1
     )
   endif()
 
-  target_compile_options(QWebdav-qt${QT_VERSION}
+  target_compile_options(qwebdav-qt${QT_VERSION}
     PRIVATE
       -Wno-overloaded-virtual
   )
 
-  target_include_directories(QWebdav-qt${QT_VERSION}
+  target_include_directories(qwebdav-qt${QT_VERSION}
     INTERFACE
       "$<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}/QWebdav>"
   )
 
-  target_link_libraries(QWebdav-qt${QT_VERSION}
+  target_link_libraries(qwebdav-qt${QT_VERSION}
     PUBLIC
       Qt${QT_VERSION}::Core
       Qt${QT_VERSION}::Network
       Qt${QT_VERSION}::Xml
   )
 
-  set_target_properties(QWebdav-qt${QT_VERSION}
+  set_target_properties(qwebdav-qt${QT_VERSION}
     PROPERTIES
       VERSION ${QWebdav_VERSION}
       SOVERSION ${QWebdav_SOVERSION}
-      EXPORT_NAME "QWebdav-qt${QT_VERSION}"
+      EXPORT_NAME "qwebdav-qt${QT_VERSION}"
   )
 
   install(
-    TARGETS QWebdav-qt${QT_VERSION}
+    TARGETS qwebdav-qt${QT_VERSION}
     EXPORT QWebdavTargets
     ${KDE_INSTALL_TARGETS_DEFAULT_ARGS}
   )
@@ -54,12 +54,12 @@ endfunction()
 
 if(WITH_QT5)
   add_qwebdav_library(5)
-  add_library(QWebdav ALIAS QWebdav-qt5)
+  add_library(QWebdav ALIAS qwebdav-qt5)
 endif()
 if(WITH_QT6)
   add_qwebdav_library(6)
   if(NOT TARGET QWebdav)
-    add_library(QWebdav ALIAS QWebdav-qt6)
+    add_library(QWebdav ALIAS qwebdav-qt6)
   endif()
 endif()
 

--- a/qwebdavlib/qwebdav-qt5.cmake.pc.in
+++ b/qwebdavlib/qwebdav-qt5.cmake.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include/QWebdav
 Name: libqwebdav-qt5
 Description: Qt WebDAV library
 Version: $$VERSION
-Libs: -L${libdir} -lQWebdav-qt5
+Libs: -L${libdir} -lqwebdav-qt5
 Requires: Qt5Core Qt5Network Qt5Xml
 Cflags: -I${includedir}
 

--- a/qwebdavlib/qwebdav-qt5.cmake.pc.in
+++ b/qwebdavlib/qwebdav-qt5.cmake.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include/QWebdav
 
 Name: libqwebdav-qt5
 Description: Qt WebDAV library
-Version: $$VERSION
+Version: @QWebdav_VERSION@
 Libs: -L${libdir} -lqwebdav-qt5
 Requires: Qt5Core Qt5Network Qt5Xml
 Cflags: -I${includedir}

--- a/qwebdavlib/qwebdav-qt6.cmake.pc.in
+++ b/qwebdavlib/qwebdav-qt6.cmake.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include/QWebdav
 
 Name: libqwebdav-qt6
 Description: Qt WebDAV library
-Version: $$VERSION
+Version: @QWebdav_VERSION@
 Libs: -L${libdir} -lqwebdav-qt6
 Requires: Qt6Core Qt6Network Qt6Xml
 Cflags: -I${includedir}

--- a/qwebdavlib/qwebdav-qt6.cmake.pc.in
+++ b/qwebdavlib/qwebdav-qt6.cmake.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include/QWebdav
 Name: libqwebdav-qt6
 Description: Qt WebDAV library
 Version: $$VERSION
-Libs: -L${libdir} -lQWebdav-qt6
+Libs: -L${libdir} -lqwebdav-qt6
 Requires: Qt6Core Qt6Network Qt6Xml
 Cflags: -I${includedir}
 

--- a/qwebdavlibExample/CMakeLists.txt
+++ b/qwebdavlibExample/CMakeLists.txt
@@ -12,19 +12,64 @@ project(QWebdavExample
 
 set(CMAKE_AUTOMOC ON)
 
-# If we're building as part of the QWebdav repository, we already
-# have the targets available.
+# If we're building as part of the QWebDAV top-level build, we already
+# have the target QWebdav available. In that case, do only the CMake-
+# based build.
 if(NOT TARGET QWebdav)
-  find_package(QWebdav REQUIRED)
+  # Outside of the QWebDAV top-level build, demonstrate both
+  # CMake and pkgconfig approaches.
+
+  # PkgConfig, first figure out which Qt version we want
+  set(QT5_REQUIRED_VERSION 5.15.0)
+  set(QT6_REQUIRED_VERSION 6.5.0)
+  find_package(Qt6 ${QT6_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
+  find_package(Qt5 ${QT5_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
+
+  if(NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
+    message(FATAL_ERROR "No installed Qt version found.")
+  endif()
+
+  find_package(PkgConfig)
+  if(PkgConfig_FOUND)
+    if(TARGET Qt6::Core)
+      pkg_check_modules(QWebdav IMPORTED_TARGET qwebdav-qt6)
+    endif()
+    if(TARGET Qt5::Core AND NOT TARGET PkgConfig::QWebdav)
+      pkg_check_modules(QWebdav IMPORTED_TARGET qwebdav-qt5)
+    endif()
+  endif()
+
+  find_package(QWebdav 1.0) # Works with whatever Qt versions are installed
+
+  if(NOT TARGET QWebdav AND NOT TARGET PkgConfig::QWebdav)
+    message(FATAL_ERROR "No installed QWebDAV found.")
+  endif()
 endif()
 
-add_executable(QWebdavExample)
-target_sources(QWebdavExample
-  PRIVATE
-    main.cpp
-    qexample.cpp
-)
-target_link_libraries(QWebdavExample
-  PRIVATE
-    QWebdav
-)
+if(TARGET QWebdav)
+  message(STATUS "Building QWebdavExample with CMake-found library")
+  add_executable(QWebdavExample-cmake)
+  target_sources(QWebdavExample-cmake
+    PRIVATE
+      main.cpp
+      qexample.cpp
+  )
+  target_link_libraries(QWebdavExample-cmake
+    PRIVATE
+      QWebdav
+  )
+endif()
+
+if(TARGET PkgConfig::QWebdav)
+  message(STATUS "Building QWebdavExample with PkgConfig-found library")
+  add_executable(QWebdavExample-pkgconfig)
+  target_sources(QWebdavExample-pkgconfig
+    PRIVATE
+      main.cpp
+      qexample.cpp
+  )
+  target_link_libraries(QWebdavExample-pkgconfig
+    PRIVATE
+      PkgConfig::QWebdav
+  )
+endif()

--- a/qwebdavlibExample/CMakeLists.txt
+++ b/qwebdavlibExample/CMakeLists.txt
@@ -12,7 +12,11 @@ project(QWebdavExample
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(QWebdav REQUIRED)
+# If we're building as part of the QWebdav repository, we already
+# have the targets available.
+if(NOT TARGET QWebdav)
+  find_package(QWebdav REQUIRED)
+endif()
 
 add_executable(QWebdavExample)
 target_sources(QWebdavExample


### PR DESCRIPTION
Make the installed library names (more) the same when installed through CMake or qmake. Document how to consume the library. Write an example. Fix bug in the CMake-generated pkgconfig file.