### PR TITLE
Another round of CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(QWebdav
   LANGUAGES CXX
 )
 
+# By default, look for and support both versions of Qt, but they
+# can be individually turned off with e.g. -DENABLE_QT5=OFF
+option(ENABLE_QT5 "Search for Qt5 libraries and build ${PROJECT_NAME} for Qt5 if found" ON)
+option(ENABLE_QT6 "Search for Qt6 libraries and build ${PROJECT_NAME} for Qt6 if found" ON)
+
 ### Find ECM up-front and complain otherwise
 #
 #
@@ -37,8 +42,12 @@ include(CMakePackageConfigHelpers)
 set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
 set(QT5_REQUIRED_VERSION 5.15.0)
 set(QT6_REQUIRED_VERSION 6.5.0)
-find_package(Qt6 ${QT6_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
-find_package(Qt5 ${QT5_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
+if(ENABLE_QT6)
+  find_package(Qt6 ${QT6_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
+endif()
+if(ENABLE_QT5)
+  find_package(Qt5 ${QT5_REQUIRED_VERSION} CONFIG COMPONENTS Core Network Xml)
+endif()
 
 set(WITH_QT5 FALSE) # Used when creating the Config.cmake file
 set(WITH_QT6 FALSE)
@@ -46,9 +55,15 @@ if(TARGET Qt5::Core)
   message(STATUS "Building Qt5 version of ${PROJECT_NAME}")
   set(WITH_QT5 TRUE)
 endif()
+if(ENABLE_QT5 AND NOT TARGET Qt5::Core)
+  message(STATUS "Qt5 enabled but not found.")
+endif()
 if(TARGET Qt6::Core)
   message(STATUS "Building Qt6 version of ${PROJECT_NAME}")
   set(WITH_QT6 TRUE)
+endif()
+if(ENABLE_QT6 AND NOT TARGET Qt6::Core)
+  message(STATUS "Qt5 enabled but not found.")
 endif()
 if(NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
   # If neither is found, complain about Qt5 because then the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,27 +95,6 @@ ecm_setup_version(${PROJECT_VERSION}
 add_subdirectory(qwebdavlib)
 add_subdirectory(qwebdavlibExample)
 
-### CMake Configuration Files
-#
-#
-configure_package_config_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/QWebdavConfig.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/QWebdavConfig.cmake"
-  INSTALL_DESTINATION ${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav
-)
-install(
-  FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/QWebdavConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/QWebdavConfigVersion.cmake"
-  DESTINATION "${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav"
-  COMPONENT devel
-)
-install(
-  EXPORT QWebdavTargets
-  DESTINATION "${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav"
-  FILE QWebdavTargets.cmake
-)
-
 ### PackageConfig files
 #
 # These are slightly different from the qmake-produced

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,18 +80,13 @@ feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND FATAL_ON_MISSING_REQUIRED_PACKA
 
 ### QWebdav version header is independent of build type
 #
-#
+# Generate one copy in the top-level, this is installed to
+# multiple locations (per-Qt-version)
 ecm_setup_version(${PROJECT_VERSION}
   VARIABLE_PREFIX QWebdav
-  VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/qwebdav_version.h"
-  PACKAGE_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/QWebdavConfigVersion.cmake"
+  VERSION_HEADER "${CMAKE_BINARY_DIR}/qwebdav_version.h"
+  PACKAGE_VERSION_FILE "${CMAKE_BINARY_DIR}/QWebdavConfigVersion.cmake"
   SOVERSION 1
-)
-install(
-  FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/qwebdav_version.h"
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QWebdav
-  COMPONENT devel
 )
 
 ### Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ endif()
 
 set(WITH_QT5 FALSE) # Used when creating the Config.cmake file
 set(WITH_QT6 FALSE)
-if(TARGET Qt5::Core)
+if(ENABLE_QT5 AND TARGET Qt5::Core)
   message(STATUS "Building Qt5 version of ${PROJECT_NAME}")
   set(WITH_QT5 TRUE)
 endif()
 if(ENABLE_QT5 AND NOT TARGET Qt5::Core)
   message(STATUS "Qt5 enabled but not found.")
 endif()
-if(TARGET Qt6::Core)
+if(ENABLE_QT6 AND TARGET Qt6::Core)
   message(STATUS "Building Qt6 version of ${PROJECT_NAME}")
   set(WITH_QT6 TRUE)
 endif()
@@ -75,6 +75,8 @@ if(NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
       URL "https://qt.io/"
   )
 endif()
+
+feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 ### QWebdav version header is independent of build type
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(ENABLE_QT6 AND TARGET Qt6::Core)
   set(WITH_QT6 TRUE)
 endif()
 if(ENABLE_QT6 AND NOT TARGET Qt6::Core)
-  message(STATUS "Qt5 enabled but not found.")
+  message(STATUS "Qt6 enabled but not found.")
 endif()
 if(NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
   # If neither is found, complain about Qt5 because then the

--- a/qwebdavlib/CMakeLists.txt
+++ b/qwebdavlib/CMakeLists.txt
@@ -56,6 +56,7 @@ function(add_qwebdav_library QT_VERSION)
   # One copy of the headers per Qt-version, even though they are
   # identical: this is so that you can build packages of Qt5 and Qt6
   # libraries separately and they won't collide over the headers.
+  set(_includedir ${KDE_INSTALL_INCLUDEDIR}/qt${QT_VERSION}/qwebdav-qt${QT_VERSION})
   install(
     FILES
       # Generated export-header isn't used (qwebdav_global contains similar
@@ -67,13 +68,13 @@ function(add_qwebdav_library QT_VERSION)
       qwebdav_global.h
       qwebdavdirparser.h
       qwebdavitem.h
-    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
+    DESTINATION ${_includedir}
     COMPONENT devel
   )
   install(
     FILES
       "${CMAKE_BINARY_DIR}/qwebdav_version.h"
-    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
+    DESTINATION ${_includedir}
     COMPONENT devel
   )
 

--- a/qwebdavlib/CMakeLists.txt
+++ b/qwebdavlib/CMakeLists.txt
@@ -47,7 +47,7 @@ function(add_qwebdav_library QT_VERSION)
 
   install(
     TARGETS qwebdav-qt${QT_VERSION}
-    EXPORT QWebdavTargets
+    EXPORT QWebdav${QT_VERSION}Targets
     ${KDE_INSTALL_TARGETS_DEFAULT_ARGS}
   )
 
@@ -75,6 +75,34 @@ function(add_qwebdav_library QT_VERSION)
       "${CMAKE_BINARY_DIR}/qwebdav_version.h"
     DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
     COMPONENT devel
+  )
+
+  ### CMake Configuration Files
+  #
+  #
+  configure_package_config_file(
+    "${CMAKE_SOURCE_DIR}/QWebdavConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/QWebdav${QT_VERSION}Config.cmake"
+    INSTALL_DESTINATION ${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav${QT_VERSION}
+  )
+  install(
+    FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/QWebdav${QT_VERSION}Config.cmake"
+    DESTINATION "${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav${QT_VERSION}"
+    COMPONENT devel
+  )
+  install(
+    FILES
+      "${CMAKE_BINARY_DIR}/QWebdavConfigVersion.cmake"
+    RENAME
+      "QWebdav${QT_VERSION}ConfigVersion.cmake"
+    DESTINATION "${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav${QT_VERSION}"
+    COMPONENT devel
+  )
+  install(
+    EXPORT QWebdav${QT_VERSION}Targets
+    DESTINATION "${KDE_INSTALL_CMAKEPACKAGEDIR}/QWebdav${QT_VERSION}"
+    FILE QWebdav${QT_VERSION}Targets.cmake
   )
 endfunction()
 

--- a/qwebdavlib/CMakeLists.txt
+++ b/qwebdavlib/CMakeLists.txt
@@ -50,31 +50,32 @@ function(add_qwebdav_library QT_VERSION)
     EXPORT QWebdavTargets
     ${KDE_INSTALL_TARGETS_DEFAULT_ARGS}
   )
+
+  generate_export_header(qwebdav-qt${QT_VERSION})
+
+  # One copy of the headers per Qt-version, even though they are
+  # identical: this is so that you can build packages of Qt5 and Qt6
+  # libraries separately and they won't collide over the headers.
+  install(
+    FILES
+      # Generated export-header isn't used (qwebdav_global contains similar
+      # definitions) and the naturalsort header is for internal use.
+      #
+      # ${CMAKE_CURRENT_BINARY_DIR}/qwebdav_export.h
+      # qnaturalsort.h
+      qwebdav.h
+      qwebdav_global.h
+      qwebdavdirparser.h
+      qwebdavitem.h
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
+    COMPONENT devel
+  )
+
 endfunction()
 
 if(WITH_QT5)
   add_qwebdav_library(5)
-  add_library(QWebdav ALIAS qwebdav-qt5)
 endif()
 if(WITH_QT6)
   add_qwebdav_library(6)
-  if(NOT TARGET QWebdav)
-    add_library(QWebdav ALIAS qwebdav-qt6)
-  endif()
 endif()
-
-# Only one export header, regardless of which libraries are built
-generate_export_header(QWebdav)
-
-# Only one copy of the headers, regardless of which libraries are built
-install(
-  FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/qwebdav_export.h
-    qnaturalsort.h
-    qwebdav.h
-    qwebdav_global.h
-    qwebdavdirparser.h
-    qwebdavitem.h
-  DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav
-  COMPONENT devel
-)

--- a/qwebdavlib/CMakeLists.txt
+++ b/qwebdavlib/CMakeLists.txt
@@ -70,7 +70,12 @@ function(add_qwebdav_library QT_VERSION)
     DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
     COMPONENT devel
   )
-
+  install(
+    FILES
+      "${CMAKE_BINARY_DIR}/qwebdav_version.h"
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/QWebdav${QT_VERSION}
+    COMPONENT devel
+  )
 endfunction()
 
 if(WITH_QT5)

--- a/qwebdavlibExample/CMakeLists.txt
+++ b/qwebdavlibExample/CMakeLists.txt
@@ -35,6 +35,11 @@ if(NOT TARGET QWebdav)
   if(NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
     message(FATAL_ERROR "No installed Qt version found.")
   endif()
+  if(TARGET Qt6::Core)
+    set(QT_VERSION 6)
+  else()
+    set(QT_VERSION 5)
+  endif()
 
   find_package(PkgConfig)
   if(PkgConfig_FOUND)
@@ -46,7 +51,7 @@ if(NOT TARGET QWebdav)
     endif()
   endif()
 
-  find_package(QWebdav 1.0) # Works with whatever Qt versions are installed
+  find_package(QWebdav${QT_VERSION} 1.0) # Works with whatever Qt versions are installed
 
   if(NOT TARGET QWebdav AND NOT TARGET PkgConfig::QWebdav)
     message(FATAL_ERROR "No installed QWebDAV found.")

--- a/qwebdavlibExample/CMakeLists.txt
+++ b/qwebdavlibExample/CMakeLists.txt
@@ -13,8 +13,15 @@ project(QWebdavExample
 set(CMAKE_AUTOMOC ON)
 
 # If we're building as part of the QWebDAV top-level build, we already
-# have the target QWebdav available. In that case, do only the CMake-
-# based build.
+# have a QWebdav target available -- prefer Qt6, and give it an alias.
+
+if(TARGET qwebdav-qt6)
+  add_library(QWebdav ALIAS qwebdav-qt6)
+elseif(TARGET qwebdav-qt5)
+  add_library(QWebdav ALIAS qwebdav-qt5)
+endif()
+
+# If we have a QWebdav target, do only the CMake-based build.
 if(NOT TARGET QWebdav)
   # Outside of the QWebDAV top-level build, demonstrate both
   # CMake and pkgconfig approaches.


### PR DESCRIPTION
> **Note:** MR in-progress, still needs tweaks. I know I keep picking at this, even though it feels like it should be done already.

This massages the CMake files again, so that they do install one copy of the headers per Qt version. The reason to do this is Linux distro's that ship separate `-dev` packages which also ship multiple copies of this library that are compiled for different Qt versions (e.g. _qwebdavlib-qt5_ and _qwebdavlib-qt6_). There are two separate `-dev` packages, which depend on the respective library packages. Those obviously can't install headers to the same location, so just do the thing upstream, even if it feels like "this is just duplicating files on the target system".

OTOH, why would you want a Qt5 version of this anymore.